### PR TITLE
menu font should be sans-serif by default

### DIFF
--- a/jquery.dropdown.css
+++ b/jquery.dropdown.css
@@ -1,4 +1,5 @@
 .dropdown-menu {
+	font: 14px sans-serif;
 	position: absolute;
 	z-index: 9999999;
 	display: none;


### PR DESCRIPTION
This is just my opinion, but I think it looks much nicer, and sticks with the bootstrap style
