### PR TITLE
Add window resize handling to keep drop down properly positioned

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -55,6 +55,14 @@ if(jQuery) (function($) {
 		
 		trigger.addClass('dropdown-open');
 		
+		$(window).resize(function() {
+			dropdown
+				.css({
+					left: dropdown.hasClass('anchor-right') ? 
+						trigger.offset().left - (dropdown.outerWidth() - trigger.outerWidth()) : trigger.offset().left,
+					top: trigger.offset().top + trigger.outerHeight()
+				});
+		});
 	};
 	
 	function hideDropdowns(event) {
@@ -65,6 +73,8 @@ if(jQuery) (function($) {
 		$('BODY')
 			.find('.dropdown-menu').hide().end()
 			.find('[data-dropdown]').removeClass('dropdown-open');
+			
+		$(window).unbind('resize');
 	};
 	
 	$(function () {


### PR DESCRIPTION
Hi, I was trying to use this plugin but noticed that when the window was resized with the dropdown open, the dropdown doesn't move itself to be properly positioned.  This adds that functionality with two quick statements (I think a more elegant way to handle this would be to make the CSS automatically keep it in the right place, but this is a good quick fix that looks fine).
