### PR TITLE
Bind events outside of DOM-ready callback

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -115,10 +115,8 @@ if(jQuery) (function($) {
 		
 	}
 	
-	$(function() {
-		$(document).on('click.dropdown', '[data-dropdown]', show);
-		$(document).on('click.dropdown', hide);
-		$(window).on('resize', position);
-	});
+	$(document).on('click.dropdown', '[data-dropdown]', show);
+	$(document).on('click.dropdown', hide);
+	$(window).on('resize', position);
 	
 })(jQuery);


### PR DESCRIPTION
Ensures compatibility with [jquery.turbolinks](https://github.com/kossnocorp/jquery.turbolinks) and any other pieces of code that might fire jQuery DOM-ready multiple times without completely reloading the page.

As far as I am aware, there is no downside to this. Do correct me if I am wrong :)
