### PR TITLE
Use radix in parseInt to prevent possible problems

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -9,10 +9,10 @@
  *
 */
 if(jQuery) (function($) {
-	
+
 	$.extend($.fn, {
 		dropdown: function(method, data) {
-			
+
 			switch( method ) {
 				case 'hide':
 					hide();
@@ -28,60 +28,60 @@ if(jQuery) (function($) {
 					hide();
 					return $(this).removeClass('dropdown-disabled');
 			}
-			
+
 		}
 	});
-	
+
 	function show(event) {
-		
+
 		var trigger = $(this),
 			dropdown = $(trigger.attr('data-dropdown')),
 			isOpen = trigger.hasClass('dropdown-open');
-		
+
 		// In some cases we don't want to show it
 		if( trigger !== event.target && $(event.target).hasClass('dropdown-ignore') ) return;
-		
+
 		event.preventDefault();
 		event.stopPropagation();
 		hide();
-		
+
 		if( isOpen || trigger.hasClass('dropdown-disabled') ) return;
-		
+
 		// Show it
 		trigger.addClass('dropdown-open');
 		dropdown
 			.data('dropdown-trigger', trigger)
 			.show();
-			
+
 		// Position it
 		position();
-		
+
 		// Trigger the show callback
 		dropdown
 			.trigger('show', {
 				dropdown: dropdown,
 				trigger: trigger
 			});
-		
+
 	}
-	
+
 	function hide(event) {
-		
+
 		// In some cases we don't hide them
 		var targetGroup = event ? $(event.target).parents().andSelf() : null;
-		
+
 		// Are we clicking anywhere in a dropdown?
 		if( targetGroup && targetGroup.is('.dropdown') ) {
 			// Is it a dropdown menu?
 			if( targetGroup.is('.dropdown-menu') ) {
 				// Did we click on an option? If so close it.
 				if( !targetGroup.is('A') ) return;
-			} else {	
+			} else {
 				// Nope, it's a panel. Leave it open.
 				return;
 			}
 		}
-		
+
 		// Hide any dropdown that may be showing
 		$(document).find('.dropdown:visible').each( function() {
 			var dropdown = $(this);
@@ -90,33 +90,33 @@ if(jQuery) (function($) {
 				.removeData('dropdown-trigger')
 				.trigger('hide', { dropdown: dropdown });
 		});
-		
+
 		// Remove all dropdown-open classes
 		$(document).find('.dropdown-open').removeClass('dropdown-open');
-		
+
 	}
-	
+
 	function position() {
-		
+
 		var dropdown = $('.dropdown:visible').eq(0),
 			trigger = dropdown.data('dropdown-trigger'),
-			hOffset = trigger ? parseInt(trigger.attr('data-horizontal-offset') || 0) : null,
-			vOffset = trigger ? parseInt(trigger.attr('data-vertical-offset') || 0) : null;
-		
+			hOffset = trigger ? parseInt(trigger.attr('data-horizontal-offset') || 0, 10) : null,
+			vOffset = trigger ? parseInt(trigger.attr('data-vertical-offset') || 0, 10) : null;
+
 		if( dropdown.length === 0 || !trigger ) return;
-		
+
 		// Position the dropdown
 		dropdown
 			.css({
-				left: dropdown.hasClass('dropdown-anchor-right') ? 
+				left: dropdown.hasClass('dropdown-anchor-right') ?
 					trigger.offset().left - (dropdown.outerWidth() - trigger.outerWidth()) + hOffset : trigger.offset().left + hOffset,
 				top: trigger.offset().top + trigger.outerHeight() + vOffset
 			});
-		
+
 	}
-	
+
 	$(document).on('click.dropdown', '[data-dropdown]', show);
 	$(document).on('click.dropdown', hide);
 	$(window).on('resize', position);
-	
+
 })(jQuery);


### PR DESCRIPTION
The second parameter of parseInt should be specified to avoid possible problems, It is also reported as an error by JSHint.

Also some whitespace has been removed as part of the commit.

See:
- http://jslinterrors.com/missing-radix-parameter/
- http://nicolaasmatthijs.blogspot.cz/2009/05/missing-radix-parameter.html
