### PR TITLE
Add component.json to allow simple installation through Bower

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,11 @@
+{
+  "name": "jquery-dropdown",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/claviska/jquery-dropdown.git"
+  },
+  "dependencies": {
+    "jquery": "~1.7.1"
+  }
+}


### PR DESCRIPTION
Component.json was added, to allow installation through [Bower](https://github.com/twitter/bower).

Dependency to jquery 1.7.1+ is defined here.

If you merge this, please also tag then the current HEAD as "0.0.1" (the same version as in component.json), so dependencies to this specified jquery-dropdown version could be defined. (And the version as well as new tag should be increased once new version is released.)
