### PR TITLE
select elements inside drop downs

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -67,6 +67,10 @@ if(jQuery) (function($) {
 	
 	function hide(event) {
 		
+		// MT - stop hiding if target is document, this seems to be if you click on select options (Firefox)
+		if (event && event.target === document)
+	        	return;
+		
 		// In some cases we don't hide them
 		var targetGroup = event ? $(event.target).parents().addBack() : null;
 		


### PR DESCRIPTION
Hello,

I noticed a small bug in the behaviour of the dropdown panels. In that if you had a select element (normal dropdown), when you selected a item on that drop down (e.g. the option element) the hide handler would get fired but in firefox the target is document so it caused the drop down to hide itself.

I've just put in a check to see if the target is document, as in theory if the user clicks elsewhere, it should never actually be document, but then again I wouldn't call myself a hardcore html / js expert so your welcome to change it to something else.

Kind Regards

Marlon
