### PR TITLE
Fix non-correct code in show()

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -39,7 +39,7 @@ if(jQuery) (function($) {
 			isOpen = trigger.hasClass('dropdown-open');
 		
 		// In some cases we don't want to show it
-		if( trigger !== event.target && $(event.target).hasClass('dropdown-ignore') ) return;
+		if( trigger.hasClass('dropdown-ignore') ) return;
 		
 		event.preventDefault();
 		event.stopPropagation();


### PR DESCRIPTION
If you want to ignore invocation of show(), you should check the trigger, not parent elements. Also, $(this) will never be equal to event.target. Correct check is if( $(this).get(0) !== event.target) {  }
