### PR TITLE
Add a way to prevent hide action.

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -88,7 +88,7 @@ if (jQuery) (function ($) {
         }
 
         // Hide any dropdown that may be showing
-        $(document).find('.dropdown:visible').each(function () {
+        $(document).find('.dropdown:visible').not('.prevent-hide').each(function () {
             var dropdown = $(this);
             dropdown
 				.hide()


### PR DESCRIPTION
In our app development, we found it necessary to have a way to block the hiding of the dropdown programmatically for particular cases. This is what we are using in our code, and it seems like a thing that could be useful to have pulled in.

The way we use it is, for example, in some function where we don't have access to `event` to block propagation:

```javascript
function doSomeActionWhileDropdownIsOpen() {
    var dropdown = $('#dropdown-panel');
    dropdown.addClass('prevent-hide');
    // do things (e.g. allow user to click places)
    dropdown.removeClass('prevent-hide')
}
```