### PR TITLE
Fixing incorrect path names in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "jquery-jq-dropdown",
   "version": "2.0.0",
   "main": [
-    "./jquery.dropdown.min.css",
+    "./jquery.dropdown.less",
     "./jquery.dropdown.js"
   ],
   "dependencies": {

--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,8 @@
   "name": "jquery-jq-dropdown",
   "version": "2.0.0",
   "main": [
-    "./jquery.jq-dropdown.css",
-    "./jquery.jq-dropdown.js"
+    "./jquery.dropdown.min.css",
+    "./jquery.dropdown.js"
   ],
   "dependencies": {
     "jquery": ">=1.8.0"


### PR DESCRIPTION
Love your plugin! 

For anyone using gulp/grunt and continuous integration with bower your bower.js had invalid files listed in the main section so they wouldn't be copied over to the correct directories. Thought I'd share fix.