### PR TITLE
Fix bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,8 @@
   "name": "jquery-jq-dropdown",
   "version": "2.0.1",
   "main": [
-    "./jquery.dropdown.less",
-    "./jquery.dropdown.js"
+    "./jquery.dropdown.min.css",
+    "./jquery.dropdown.min.js"
   ],
   "dependencies": {
     "jquery": ">=1.8.0"


### PR DESCRIPTION
The `main` entries are loaded by something like
[wiredep](https://github.com/taptapship/wiredep) usually and should
contain compiled js/css files.