### PR TITLE
Fix bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "jquery-jq-dropdown",
   "version": "2.0.1",
   "main": [
-    "./jquery.dropdown.less",
+    "./jquery.dropdown.css",
     "./jquery.dropdown.js"
   ],
   "dependencies": {


### PR DESCRIPTION
The `main` entries are loaded by something like
[wiredep](https://github.com/taptapship/wiredep) usually and should
contain compiled js/css files.