### PR TITLE
fixed project name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
-  "name": "jquery-jq-dropdown",
-  "version": "2.0.1",
+  "name": "jquery-dropdown",
   "main": [
     "./jquery.dropdown.css",
     "./jquery.dropdown.js"


### PR DESCRIPTION
looks like the name got messed up by a global find/replace `dropdown`->`jq-dropdown` d80edcd80f3abb20606fcf1fce752198e0104934

I see this has been fixed in `component.json` (and similar files) 6f9973121150882499529c6fdfc6c7581152f750

I've also removed `version` from `bower.json`, since bower prefers to work off of git tags. Less future maintenance! :)