### PR TITLE
Feature/preventable hide

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -87,8 +87,10 @@ if (jQuery) (function ($) {
             }
         }
 
-        // Hide any jq-dropdown that may be showing
-        $(document).find('.jq-dropdown:visible').each(function () {
+        // Trigger the event early, so that it might be prevented on the visible popups
+        var hideEvent = jQuery.Event("hide");
+
+        $(document).find('.dropdown:visible').each(function () {
             var jqDropdown = $(this);
             jqDropdown
                 .hide()
@@ -96,9 +98,19 @@ if (jQuery) (function ($) {
                 .trigger('hide', { jqDropdown: jqDropdown });
         });
 
-        // Remove all jq-dropdown-open classes
-        $(document).find('.jq-dropdown-open').removeClass('jq-dropdown-open');
+        if(!hideEvent.isDefaultPrevented()) {
+            // Hide any jq-dropdown that may be showing
+            $(document).find('.dropdown:visible').each(function () {
+                var jqDropdown = $(this);
+                jqDropdown
+                    .hide()
+                    .removeData('jq-dropdown-trigger')
+                    .trigger('hide', { jqDropdown: jqDropdown });
+            });
 
+            // Remove all jq-dropdown-open classes
+            $(document).find('.jq-dropdown-open').removeClass('jq-dropdown-open');
+        }
     }
 
     function position() {


### PR DESCRIPTION
Re-opening #91

These changes poll whether `event.preventDefault()` has been called when hiding the dropdown, to allow programatically opting out of hiding it. The use case for this is to allow in certain cases the dropdown to stay open when an area outside of the dropdown has been clicked - for example, another div that is not necessarily contained in the dropdown div.