### PR TITLE
Made using dropdowns in dropped down panels work.

### DIFF
--- a/jquery.dropdown.js
+++ b/jquery.dropdown.js
@@ -48,7 +48,7 @@ if (jQuery) (function ($) {
         } else {
             if (trigger !== object.target && $(object.target).hasClass('jq-dropdown-ignore')) return;
         }
-        hide();
+        hide(event);
 
         if (isOpen || trigger.hasClass('jq-dropdown-disabled')) return;
 
@@ -102,14 +102,20 @@ if (jQuery) (function ($) {
     }
 
     function position() {
+        $('.jq-dropdown:visible').each(function() {
+            positionJqDropdown($( this ));
+        });
+    }
+    
+    function positionJqDropdown(jqDropdown) {
 
-        var jqDropdown = $('.jq-dropdown:visible').eq(0),
-            trigger = jqDropdown.data('jq-dropdown-trigger'),
-            hOffset = trigger ? parseInt(trigger.attr('data-horizontal-offset') || 0, 10) : null,
-            vOffset = trigger ? parseInt(trigger.attr('data-vertical-offset') || 0, 10) : null;
-
-        if (jqDropdown.length === 0 || !trigger) return;
-
+        var trigger = jqDropdown.data('jq-dropdown-trigger');
+        
+        if (!trigger) return;
+        
+        var hOffset = parseInt(trigger.attr('data-horizontal-offset') || 0, 10),
+            vOffset = parseInt(trigger.attr('data-vertical-offset') || 0, 10);
+ 
         // Position the jq-dropdown relative-to-parent...
         if (jqDropdown.hasClass('jq-dropdown-relative')) {
             jqDropdown.css({


### PR DESCRIPTION
This is a small change against the latest tagged version (2.0.3) that allows you to use jqDropdowns in panels that have been opened by jqDropdown. It makes use of what is already there (e.g. preventing the "parent" dropdown from being hidden by using the parameter of the "hide" function).

I've read that the code is no longer maintained. So I'm mainly creating this request to make other users aware of the solution. For me, jqDropdown is *exactly* what I was missing when implementing my jquery ui based application. Great Stuff, thanks!